### PR TITLE
[feat][TC-84] Adiciona scroll ao componente de extrato

### DIFF
--- a/apps/bytebank/src/app/(pages)/(financial-pages)/_components/extract/index.tsx
+++ b/apps/bytebank/src/app/(pages)/(financial-pages)/_components/extract/index.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { BytebankCard, BytebankDivider, BytebankSnackbar, BytebankText, SnackbarData } from '@bytebank/shared';
+import {
+  BytebankCard,
+  BytebankDivider,
+  BytebankSnackbar,
+  BytebankText,
+  SnackbarData,
+} from '@bytebank/shared';
 import { Box, Skeleton } from '@mui/material';
 import { format } from 'date-fns';
 import React, { useEffect, useState } from 'react';
@@ -25,13 +31,11 @@ export function BytebankExtract() {
   useEffect(() => {
     const getTransactions = async () => {
       if (!user) return;
-      await fetchTransactions(user)
+      await fetchTransactions(user);
     };
 
     getTransactions();
-
   }, [user]);
-
 
   const numberFormat = (value: number) =>
     value.toLocaleString('pt-BR', {
@@ -56,7 +60,10 @@ export function BytebankExtract() {
     setSnackbarData(null);
   };
 
-  const handleTransactionUpdate = async (data: Transaction, newValue: string) => {
+  const handleTransactionUpdate = async (
+    data: Transaction,
+    newValue: string
+  ) => {
     data.value = (Number(newValue) / 100).toString();
     data.date = new Date();
 
@@ -87,7 +94,7 @@ export function BytebankExtract() {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(id)
+      body: JSON.stringify(id),
     });
 
     if (response.ok) {
@@ -110,8 +117,7 @@ export function BytebankExtract() {
       message: 'Algo deu errado. Por favor, aguarde e tente novamente!',
     });
     setSnackbarOpen(true);
-  }
-
+  };
 
   return (
     <>
@@ -123,26 +129,51 @@ export function BytebankExtract() {
             </BytebankText>
           </Box>
           {/* Lista de extratos */}
-          {isLoading ?
-            <Box >
+          {isLoading ? (
+            <Box>
               <Box px={4}>
-                <Skeleton width={40} variant="text" sx={{ fontSize: '1.5rem' }} />
-                <Skeleton width="full" variant="text" sx={{ fontSize: '1.5rem' }} />
-                <Skeleton width="full" variant="text" sx={{ fontSize: '1.5rem' }} />
+                <Skeleton
+                  width={40}
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
+                <Skeleton
+                  width="full"
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
+                <Skeleton
+                  width="full"
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
               </Box>
               <Box my={2}>
                 <BytebankDivider type="horizontal" color="primary" />
               </Box>
               <Box px={4}>
-                <Skeleton width={40} variant="text" sx={{ fontSize: '1.5rem' }} />
-                <Skeleton width="full" variant="text" sx={{ fontSize: '1.5rem' }} />
-                <Skeleton width="full" variant="text" sx={{ fontSize: '1.5rem' }} />
+                <Skeleton
+                  width={40}
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
+                <Skeleton
+                  width="full"
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
+                <Skeleton
+                  width="full"
+                  variant="text"
+                  sx={{ fontSize: '1.5rem' }}
+                />
               </Box>
-            </Box> :
+            </Box>
+          ) : (
             <>
               {extract?.length !== 0 ? (
                 extract?.map((itens, index) => (
-                  <Box key={index}>
+                  <Box key={index} maxHeight={'763px'} overflow={'auto'}>
                     <Box
                       width="100%"
                       display="flex"
@@ -152,7 +183,8 @@ export function BytebankExtract() {
                       fontWeight={600}
                     >
                       <BytebankText fontWeight={'bold'} color="primary">
-                        {itens.month.charAt(0).toUpperCase() + itens.month.slice(1)}
+                        {itens.month.charAt(0).toUpperCase() +
+                          itens.month.slice(1)}
                       </BytebankText>
                     </Box>
                     {itens.data.map((item: Transaction, index: number) => (
@@ -242,7 +274,7 @@ export function BytebankExtract() {
                 </Box>
               )}
             </>
-          }
+          )}
         </Box>
       </BytebankCard>
 
@@ -252,7 +284,7 @@ export function BytebankExtract() {
         item={selectedItem as Transaction}
         onSave={async (newValue) => {
           if (!selectedItem) return;
-          handleTransactionUpdate(selectedItem, newValue)
+          handleTransactionUpdate(selectedItem, newValue);
         }}
       />
       <DeleteExtractModal
@@ -261,11 +293,15 @@ export function BytebankExtract() {
         item={selectedItem}
         onConfirm={async () => {
           if (!selectedItem) return;
-          setDeleteModalOpen(false)
-          handleTransactionDelete(selectedItem.id)
+          setDeleteModalOpen(false);
+          handleTransactionDelete(selectedItem.id);
         }}
       />
-      <BytebankSnackbar open={snackbarOpen} data={snackbarData} onClose={closeSnackbar} />
+      <BytebankSnackbar
+        open={snackbarOpen}
+        data={snackbarData}
+        onClose={closeSnackbar}
+      />
     </>
   );
 }


### PR DESCRIPTION
## 🧠 Contexto e objetivo da mudança
Adiciona um scroll ao componente de extrato para não ultrapassar o tamanho do conteúdo da tela caso tenha um grande volume de transações disponíveis para carregar.

## 📸 Imagem ou evidência visual (quando aplicável)
![image](https://github.com/user-attachments/assets/c3954061-dfa4-40ff-8e1c-ede28cd16183)

## 🧪 Passos detalhados para testar
 Descreva como o revisor pode **reproduzir/testar** essa mudança localmente:

1. Clone o repositório e acesse a branch do PR
2. Rode o projeto com: `npm run dev` / `pnpm dev` / `dotnet run` (dependendo do projeto)
3. LOgue no sistema
4. Na tela de home principal, adicione transações e verifique se o card do extrato mantém a altura do conteúdo e habilita o scroll.

## 🔧 Tipo da alteração

- [x] feat

## ✅ Checklist

- [x] O código segue os padrões definidos no projeto
- [x] Foi testado manualmente
- [ ] Foram criados/atualizados testes automatizados (quando aplicável)
- [ ] A documentação (README, comentários, etc) foi atualizada
- [ ] Este PR está relacionado a alguma issue (adicione abaixo, se aplicável)

## 🧩 Issues relacionadas

> Resolves #84